### PR TITLE
Add other possible network name to docs

### DIFF
--- a/docs/develop/metamask/custom-tokens.md
+++ b/docs/develop/metamask/custom-tokens.md
@@ -23,7 +23,7 @@ The other fields will auto-populate. Click on Save and then click on Add Tokens.
 
 **Configuring `Matic TEST` tokens to Metamask**
 
-You will also need to configure the `TEST` tokens to Matic’s Testnet for visualization if you are following the introductory Matic.js tutorial. **Switch the network on Metamask to point to the Matic testnet - https://rpc-mumbai.matic.today **. On Metamask, this will be shown as `Private Network`.
+You will also need to configure the `TEST` tokens to Matic’s Testnet for visualization if you are following the introductory Matic.js tutorial. **Switch the network on Metamask to point to the Matic testnet - https://rpc-mumbai.matic.today **. On Metamask, this will be shown as `Private Network` or whatever you have named it when adding the custom rpc eg. `mumbai`.
 
 The corresponding `TEST` token address on Matic testnet is `0xc7bb71b405ea25A9251a1ea060C2891b84BE1929`. Note that this token contract address is different from that of Goerli - since this is the `TEST` token on the Matic Network. A detailed, screen-by-screen guide to add custom tokens is shown here:
 


### PR DESCRIPTION
The name on metamask isn't necessarily `private network`