### PR TITLE
fix: matic gas token doc fix

### DIFF
--- a/docs/develop/network-details/gas-token.mdx
+++ b/docs/develop/network-details/gas-token.mdx
@@ -22,9 +22,10 @@ import TabItem from '@theme/TabItem';
 # Mumbai :fuelpump: 
 [MATIC token](https://etherscan.io/token/0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0) is the native token of matic network. This is similar to Ether in Ethereum. To interact with  matic network, [MATIC](https://etherscan.io/token/0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0) tokens are required to pay as gas fees.
 
-- On the Matic chain, the Matic tokens works as native token, but also as the an ERC20 token, both at the same time. This means that a user can pay gas with MATIC as well as send MATIC to other accounts.
+- On the Matic chain, the Matic tokens works as native token. This means that a user can pay gas with MATIC as well as send MATIC to other accounts same way as they use ETH to pay gas fees on Ethereum and send ETH to others.
+- This is an example [script](https://gist.github.com/rahuldamodar94/ea3bc4c551e6fc2d318767dcd7e5bffe) to send MATIC tokens from one account to another on the Matic chain.
 
-Getting the Matic token is really easy. You can deposit MATIC token from Goerli to Mumbai using the plasma contracts deployed on Goerli.
+Getting the Matic token is really easy. You can deposit MATIC token from Goerli to Mumbai using the plasma or PoS contracts deployed on Goerli. 
 
 Ways to get matic token for Mumbai :
 
@@ -43,9 +44,10 @@ Ways to get matic token for Mumbai :
 # Matic Network :fuelpump: 
 [MATIC token](https://etherscan.io/token/0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0) is the native token of matic network. This is similar to Ether in Ethereum. To interact with  matic network, [MATIC](https://etherscan.io/token/0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0) tokens are required to pay as gas fees.
 
-- On the Matic chain, the Matic tokens works as native token, but also as the an ERC20 token, both at the same time. This means that a user can pay gas with MATIC as well as send MATIC to other accounts.
+- On the Matic chain, the Matic tokens works as native token. This means that a user can pay gas with MATIC as well as send MATIC to other accounts same way as they use ETH to pay gas fees on Ethereum and send ETH to others.
+- This is an example [script](https://gist.github.com/rahuldamodar94/ea3bc4c551e6fc2d318767dcd7e5bffe) to send MATIC tokens from one account to another on the Matic chain.
 
-Getting the Matic token is really easy. You can deposit MATIC token from Ethereum to Matic network using the plasma contracts deployed on Ethereum.
+Getting the Matic token is really easy. You can deposit MATIC token from Goerli to Mumbai using the plasma or PoS contracts deployed on Goerli. 
 
 - **Step 1: Get MATIC Token:**
     - On Ethereum, the matic ERC20 token can be purchased from the following exchanges :-


### PR DESCRIPTION
Made a few edits in the matic gas token doc. Had mention that matic token is also a erc20 token on matic. so some users interpreted in wrongly and tried to send matic like they send erc20 token but they failed. So i have made the doc correction and also added a small script that shows how matic is actually sent. 