### PR TITLE
Notes from following the instructions

### DIFF
--- a/docs/integrate/full-node-deployment.md
+++ b/docs/integrate/full-node-deployment.md
@@ -69,9 +69,6 @@ We have created simple Ansible playbooks to setup a full node.
 
 - Login to the remote machine
 - Configure the following in `~/.heimdalld/config/config.toml`:
-    ```js
-    moniker=<enter unique identifier>
-    ```
     
     ```js
     seeds="4cd60c1d76e44b05f7dfd8bab3f447b119e87042@54.147.31.250:26656"
@@ -97,7 +94,7 @@ Incase your Heimdall has stopped syncing you can add additional seeds to your `c
 In case your Bor node has stopped syncing, you can add additional bootnodes to your `start.sh` file:
 
 ```js
---bootnodes enode://320553cda00dfc003f499a3ce9598029f364fbb3ed1222fdc20a94d97dcc4d8ba0cd0bfa996579dcc6d17a534741fb0a5da303a90579431259150de66b597251@54.147.31.250:30303,enode://f0f48a8781629f95ff02606081e6e43e4aebd503f3d07fc931fad7dd5ca1ba52bd849a6f6c3be0e375cf13c9ae04d859c4a9ae3546dc8ed4f10aa5dbb47d4998@34.226.134.117:30303
+--bootnodes "enode://320553cda00dfc003f499a3ce9598029f364fbb3ed1222fdc20a94d97dcc4d8ba0cd0bfa996579dcc6d17a534741fb0a5da303a90579431259150de66b597251@54.147.31.250:30303,enode://f0f48a8781629f95ff02606081e6e43e4aebd503f3d07fc931fad7dd5ca1ba52bd849a6f6c3be0e375cf13c9ae04d859c4a9ae3546dc8ed4f10aa5dbb47d4998@34.226.134.117:30303"
 ```
 
 - In case you want to turn `trace` on for Bor, add the following flag to the `bor` start params in `~/node/bor/start.sh`:


### PR DESCRIPTION
moniker is auto generated
missing "" on multiple bootnodes (maybe not required)

This doesnt seem to be the latest changes as the section "To check if Heimdall is synced" is not reflected here. It would be nice to say heimdall sync could take approx 7-8 hours or so. Check `latest_block_height` and https://mumbai-explorer.matic.today/blocks to get an idea of how far it is from syncing. (assuming `latest_block_height`is the latest block synced)

*Another thing i noticed is that only the mumbai instructions show the `To check if Heimdall is synced` instructions