### PR TITLE
URL fix to hyperlink text : Biconomy  and GSN

### DIFF
--- a/docs/develop/metatransactions/getting-started.md
+++ b/docs/develop/metatransactions/getting-started.md
@@ -17,6 +17,6 @@ Assuming your familiarity with the different approaches you can take to integrat
 
 To integrate your DApp with Meta Transactions on Matic, you can choose to go with either the following two relayers or spin up a custom solution:
 
-1. [Biconomy](metatransactions-biconomy)
-2. [Gas Station Network(GSN)](metatransactions-gsn)
+1. [Biconomy](https://docs.matic.network/docs/develop/metatransactions/metatransactions-biconomy)
+2. [Gas Station Network(GSN)](https://docs.matic.network/docs/develop/metatransactions/metatransactions-gsn)
 3. Custom solutions

--- a/docs/develop/metatransactions/getting-started.md
+++ b/docs/develop/metatransactions/getting-started.md
@@ -17,6 +17,6 @@ Assuming your familiarity with the different approaches you can take to integrat
 
 To integrate your DApp with Meta Transactions on Matic, you can choose to go with either the following two relayers or spin up a custom solution:
 
-1. [Biconomy](https://docs.matic.network/docs/develop/metatransactions/metatransactions-biconomy)
-2. [Gas Station Network(GSN)](https://docs.matic.network/docs/develop/metatransactions/metatransactions-gsn)
+1. [Biconomy](metatransactions-biconomy.md)
+2. [Gas Station Network(GSN)](metatransactions-gsn.md)
 3. Custom solutions


### PR DESCRIPTION
Resulting in `page not found` as on click it is going to `https://docs.matic.network/docs/develop/metatransactions/getting-started/metatransactions-biconomy` instead of just `https://docs.matic.network/docs/develop/metatransactions/metatransactions-biconomy`