### PR TITLE
fix: Switch links for "Ethereum + Matic with" links

### DIFF
--- a/docs/home/new-to-matic.md
+++ b/docs/home/new-to-matic.md
@@ -12,8 +12,8 @@ Matic Network is a scaling solution for public blockchains. Based on an adapted 
 ### Types of Interaction on Matic
 
 * [Matic PoS chain](/docs/develop/getting-started)
-* [Ethereum + Matic with PoS bridge](https://docs.matic.today/docs/develop/ethereum-matic/plasma/getting-started)
-* [Ethereum + Matic with Plasma bridge](https://docs.matic.today/docs/develop/ethereum-matic/pos/getting-started)
+* [Ethereum + Matic with PoS bridge](https://docs.matic.today/docs/develop/ethereum-matic/pos/getting-started)
+* [Ethereum + Matic with Plasma bridge](https://docs.matic.today/docs/develop/ethereum-matic/plasma/getting-started)
 
 ### Deploy Smart Contracts
 


### PR DESCRIPTION
"Ethereum + Matic with PoS bridge" is sending to Plasma page
"Ethereum + Matic with Plasma bridge" is sending to PoS page
This PR switch the links to redirect to the correct page