### PR TITLE
Fix Spelling Error on POS `getting started` page

### DIFF
--- a/docs/develop/ethereum-matic/pos/using-sdk/getting-started.mdx
+++ b/docs/develop/ethereum-matic/pos/using-sdk/getting-started.mdx
@@ -78,7 +78,7 @@ const maticPOSClient = new MaticPOSClient({
 const maticPOSClient = new MaticPOSClient({
   network: "mainnet",
   version: "v1",
-  parentProvider: <ethereun-provider>,
+  parentProvider: <ethereum-provider>,
   maticProvider: <matic-provider>
 });
 ```


### PR DESCRIPTION
ethereun -> ethereum