### PR TITLE
Fixing typos and missing dependency.

### DIFF
--- a/docs/develop/hardhat.md
+++ b/docs/develop/hardhat.md
@@ -33,8 +33,9 @@ The sample project will ask you to install hardhat-waffle and hardhat-ethers.You
 - create .secret file in the root to store your private key
 
 ```js
+require("@nomiclabs/hardhat-ethers");
 const fs = require('fs');
-const privatekey = fs.readFileSync(".secret").toString().trim();
+const privateKey = fs.readFileSync(".secret").toString().trim();
 module.exports = {
   defaultNetwork: "matic",
   networks: {
@@ -46,7 +47,7 @@ module.exports = {
     }
   },
   solidity: {
-    version: “0.7.0”,
+    version: "0.7.0",
     settings: {
       optimizer: {
         enabled: true,


### PR DESCRIPTION
I just followed the instructions provided in this tutorial.  I needed to make these changes to actually deploy the script. 
First, I made sure to require "@nomiclabs/hardhat-ethers", so that I would not get the errory TypeError: no propery found 'getContractFactory'. 
Second, I changed the 'k' in 'privatekey' to a capital to match it's later usage.  
Finally, I changed the quotes around the solidity version so that they match the other quotes.