### PR TITLE
Update ERC1155.md to correct inconsistencies.

### DIFF
--- a/docs/develop/ethereum-matic/pos/using-sdk/erc1155.md
+++ b/docs/develop/ethereum-matic/pos/using-sdk/erc1155.md
@@ -33,15 +33,15 @@ Withdraw ERC1155 -
 
 ### Approve
 
-This is a normal ERC1155 approval so that **_ERC1155Predicate_** can call **_transferFrom_** function. Matic POS client exposes **_approveERC1155ForDeposit_** method to make this call.
+This is a normal ERC1155 approval so that **_ERC1155Predicate_** can call **_transferFrom_** function. Matic POS client exposes [**_approveERC1155ForDeposit_** ](https://github.com/maticnetwork/matic.js/blob/4bf4fa9438d56c9b5c282f456aa2c24f6ff6083d/src/index.ts#L231) method to make this call.
 
 ```jsx
-await maticPOSClient.approveERC1155ForDeposit(rootToken, tokenId, { from });
+await maticPOSClient.approveERC1155ForDeposit(rootToken, { from });
 ```
 
 ### Deposit
 
-Deposit can be done by calling **_depositFor_** on RootChainManager contract. Note that token needs to be mapped and approved for transfer beforehand. Once tokens are transferred deposit proceeds using StateSync mechanism. Matic POS client exposes **_depositSingleERC1155ForUser_** & **_depositBatchERC1155ForUser_** method to make this call.
+Deposit can be done by calling **_depositFor_** on RootChainManager contract. Note that token needs to be mapped and approved for transfer beforehand. Once tokens are transferred deposit proceeds using StateSync mechanism. Matic POS client exposes [**_depositSingleERC1155ForUser_**](https://github.com/maticnetwork/matic.js/blob/4bf4fa9438d56c9b5c282f456aa2c24f6ff6083d/src/index.ts#L245) & [**_depositBatchERC1155ForUser_**](https://github.com/maticnetwork/matic.js/blob/4bf4fa9438d56c9b5c282f456aa2c24f6ff6083d/src/index.ts#L259) method to make this call.
 
 ```jsx
 await maticPOSClient.depositSingleERC1155ForUser(


### PR DESCRIPTION
approveERC1155ForDeposit only accepts one parameter, not two.  I correct this.

I also added links to the matic.js repo so users could link directly to source control so they can confidently verify the sample code is still relevant and not stale.