### PR TITLE
Change min node version required to run Hardhat

### DIFF
--- a/docs/develop/hardhat.md
+++ b/docs/develop/hardhat.md
@@ -12,7 +12,7 @@ image: https://matic.network/banners/matic-network-16x9.png
 
 There are a few technical requirements before we start. Please install the following:
 
-- [Node.js v8+ LTS and npm](https://nodejs.org/en/) (comes with Node)
+- [Node.js v10+ LTS and npm](https://nodejs.org/en/) (comes with Node)
 - [Git](https://git-scm.com/)
 
 Once we have those installed, To install hardhat, you need to create an npm project by going to an empty folder, running npm init, and following its instructions. Once your project is ready, you should run


### PR DESCRIPTION
Hardhat doesn't support node v8 (and we'll soon stop supporting node v10, although it will probably keep working fine for a while).