### PR TITLE
updated rpc endpoint

### DIFF
--- a/docs/develop/truffle.md
+++ b/docs/develop/truffle.md
@@ -41,7 +41,7 @@ module.exports = {
       network_id: "*",       // Any network (default: none)
     },
     matic: {
-      provider: () => new HDWalletProvider(mnemonic, `https://rpc-mumbai.matic.today`),
+      provider: () => new HDWalletProvider(mnemonic, `https://rpc-mumbai.maticvigil.com`),
       network_id: 80001,
       confirmations: 2,
       timeoutBlocks: 200,


### PR DESCRIPTION
Update RPC endpoint to `https://rpc-mumbai.maticvigil.com` from `https://rpc-mumbai.matic.today` for truffle-polygon test network integration.