### PR TITLE
Include information for configuring ERC721 and ERC1155 on Görli and Mumbai

### DIFF
--- a/docs/develop/metamask/custom-tokens.md
+++ b/docs/develop/metamask/custom-tokens.md
@@ -10,11 +10,11 @@ image: https://matic.network/banners/matic-network-16x9.png
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-This page demonstrates the process of configuring/adding custom tokens to Metamask. Specifically, we have demonstrated adding the example `TEST` token to the Görli testnet as well as the Matic testnet.
+This page demonstrates the process of configuring/adding custom tokens to Metamask. Specifically, we have demonstrated adding the example `TEST` ERC20 and ERC721 tokens to the Görli testnet as well as the Matic testnet, Mumbai.
 
 You can use this process to add any custom ERC20 tokens to any network on Metamask.
 
-**Adding the `TEST` token (ERC20) to your Metamask account on Ropsten Network**
+**Adding the `TEST` token (ERC20) to your Metamask account on the Görli Network**
 
 To display `TEST` tokens on your account on the Görli Network, you can click on the Add Tokens option in Metamask. It will then navigate you to a screen. You then click on Custom Token tab and copy-paste the address below in the Token Address field.
 
@@ -24,7 +24,7 @@ The other fields will auto-populate. Click on Save and then click on Add Tokens.
 
 **Configuring `Matic TST` tokens to Metamask**
 
-You will also need to configure the `TST` tokens to Matic’s Testnet for visualization if you are following the introductory Matic.js tutorial. **Switch the network on Metamask to point to the Matic testnet - https://rpc-mumbai.matic.today **. On Metamask, this will be shown as `Private Network`or whatever you have named it when adding the custom rpc eg. `mumbai`.
+You will also need to configure the `TST` tokens to Matic’s Testnet for visualization if you are following the introductory Matic.js tutorial. **Switch the network on Metamask to point to the Matic testnet - https://rpc-mumbai.matic.today **. On Metamask, this will be shown as `Private Network` or whatever you have named it when adding the custom rpc eg. `mumbai`.
 
 The corresponding `TST` token address on Matic testnet is `0x2d7882beDcbfDDce29Ba99965dd3cdF7fcB10A1e`. Note that this token contract address is different from that of Goerli - since this is the `TST` token on the Matic Network. A detailed, screen-by-screen guide to add custom tokens is shown here:
 
@@ -43,3 +43,25 @@ You can then click on Next.
 <img src={useBaseUrl("img/metamask/configure-custom-token-3.png")} />
 
 And then click on Add Tokens. You will be navigated back to the home screen and the new token will be displayed in the token list.
+
+**Adding the `ERC721-TESTV4` token (ERC721) to your Metamask account on the Görli Network**
+
+To display `ERC721-TESTV4` tokens on your account on the Görli Network, you can click on the Add Tokens option in Metamask. It will then navigate you to a screen. You then click on Custom Token tab and copy-paste the address below in the Token Address field.
+
+The `ERC721-TESTV4` token contract address on Görli is `0xfA08B72137eF907dEB3F202a60EfBc610D2f224b`. Note that the `ERC721-TESTV4` token is an example ERC721 token contract.
+
+The token symbol is `ERC721-Testv4` and token of precision is `18`. Click on Add Tokens. The `ERC721-TESTV4` token should now be displayed on your account on Metamask.
+
+**Adding the `ERC721-TESTV4` token (ERC721) to your Metamask account on the Mumbai Network**
+
+**Switch the network on Metamask to point to the Matic testnet - https://rpc-mumbai.matic.today **. On Metamask, this will be shown as `Private Network` or whatever you have named it when adding the custom rpc eg. `mumbai`.
+
+To display `ERC721-TESTV4` tokens on your account on the Mumbai Network, you can click on the Add Tokens option in Metamask. It will then navigate you to a screen. You then click on Custom Token tab and copy-paste the address below in the Token Address field.
+
+The `ERC721-TESTV4` token contract address on Mumbai is `0x33FC58F12A56280503b04AC7911D1EceEBcE179c`. Note that the `ERC721-TESTV4` token is an example ERC721 token contract.
+
+The token symbol is `ERC721-Testv4` and token of precision is `18`. Click on Add Tokens. The `ERC721-TESTV4` token should now be displayed on your account on Metamask.
+
+**Adding a test ERC1155 token to your Metamask account**
+
+While the Polygon network supports ERC1155, [Metamask does not yet support the standard](https://metamask.zendesk.com/hc/en-us/articles/360058488651-Does-MetaMask-support-ERC-1155-). This update is expected in the fourth quarter of 2021.


### PR DESCRIPTION
Corrected "Ropsten" to "Görli"
Include instructions for (Plasma) Test ERC721 on Görli and Mumbai
Note that MetaMask does not yet support ERC1155