### PR TITLE
Minor doc fix - L1/L2 communtation

### DIFF
--- a/docs/develop/l1-l2-communication/state-transfer.md
+++ b/docs/develop/l1-l2-communication/state-transfer.md
@@ -57,9 +57,12 @@ Use the `FxBaseChildTunnel` contract from [here](https://github.com/jdkanani/fx-
 
 ```jsx
 // npm i @maticnetwork/maticjs
+// for goerli - mumbai testnet
 const maticPOSClient = new require("@maticnetwork/maticjs").MaticPOSClient({
-  maticProvider: "https://rpc-mumbai.matic.today", // replace if using mainnet
-  parentProvider: "https://rpc.slock.it/goerli", // replace if using mainnet
+  network: "testnet", // when using mainnet, replace to "mainnet" 
+  version: "mumbai",  // when using mainnet, replace to "v1"
+  maticProvider: "https://rpc-mumbai.matic.today", // when using mainnet, replace to matic mainnet RPC endpoint
+  parentProvider: "https://rpc.slock.it/goerli", // when using mainnet, replace to ethereum mainnet RPC endpoint
 });
 const proof = maticPOSClient.posRootChainManager
   .customPayload(


### PR DESCRIPTION
SDK client defaults to 'testnet' setup. Thus when using mainnet network name needs to be explicitly specified. 

https://github.com/maticnetwork/matic.js/blob/4bf4fa9438d56c9b5c282f456aa2c24f6ff6083d/src/common/SDKClient.ts#L8