### PR TITLE
Fix testnet polygonscan.com link

### DIFF
--- a/docs/develop/network-details/network.mdx
+++ b/docs/develop/network-details/network.mdx
@@ -36,7 +36,7 @@ The documentation corresponding contains details for the RPC - HTTP, WS and Dagg
 | Dagger RPC   | `https://mumbai-dagger.matic.today`   |
 | Dagger WSS   | `wss://mumbai-dagger.matic.today`  |
 | Heimdall API | `https://heimdall.api.matic.today` |
-| Block Explorer |[`https://polygon-explorer-mumbai.chainstacklabs.com`](https://polygon-explorer-mumbai.chainstacklabs.com)<br/> [`https://explorer-mumbai.maticvigil.com`](https://explorer-mumbai.maticvigil.com) <br/> [`https://mumbai-explorer.matic.today`](https://mumbai-explorer.matic.today) <br/> [`https://backup-mumbai-explorer.matic.today`](https://backup-mumbai-explorer.matic.today) <br/> [`https://polygonscan.com/`](https://polygonscan.com/)|
+| Block Explorer |[`https://polygon-explorer-mumbai.chainstacklabs.com`](https://polygon-explorer-mumbai.chainstacklabs.com)<br/> [`https://explorer-mumbai.maticvigil.com`](https://explorer-mumbai.maticvigil.com) <br/> [`https://mumbai-explorer.matic.today`](https://mumbai-explorer.matic.today) <br/> [`https://backup-mumbai-explorer.matic.today`](https://backup-mumbai-explorer.matic.today) <br/> [`https://mumbai.polygonscan.com/`](https://mumbai.polygonscan.com/)|
 
 
 > For more details: [https://static.matic.network/network/testnet/mumbai/index.json](https://static.matic.network/network/testnet/mumbai/index.json)


### PR DESCRIPTION
Testnet (Mumbai) explorer is located on the subdomain which is https://mumbai.polygonscan.com

Docs section address:
https://docs.matic.network/docs/develop/network-details/network -> Mumbai-Testnet tab -> "Block Explorer" row