### PR TITLE
truffle provider url config update

### DIFF
--- a/docs/develop/truffle.md
+++ b/docs/develop/truffle.md
@@ -41,7 +41,7 @@ module.exports = {
       network_id: "*",       // Any network (default: none)
     },
     matic: {
-      provider: () => new HDWalletProvider(mnemonic, `https://rpc-mumbai.matic.today`),
+      provider: () => new HDWalletProvider(mnemonic, `https://rpc-mumbai.maticvigil.com`),
       network_id: 80001,
       confirmations: 2,
       timeoutBlocks: 200,


### PR DESCRIPTION
**rpc-mumbai.matic.today - does not work**, replaced with: **rpc-mumbai.maticvigil.com**

- the **same as for hardhat** config: https://docs.polygon.technology/docs/develop/hardhat

Is there any reason why truffle and hardhat have different provider endpoints? 

Truffle repo issue:

@trufflesuite/truffle#3357
https://github.com/trufflesuite/truffle/issues/3357
