### PR TITLE
Replacing URLs

### DIFF
--- a/docs/develop/getting-started.md
+++ b/docs/develop/getting-started.md
@@ -72,7 +72,7 @@ All the network related details can be found in [network docs](/docs/develop/net
 - [Sidechains and Plasma](https://docs.polygon.technology/docs/home/blockchain-basics/sidechain)
 - [Polygon's architecture and Security](https://docs.polygon.technology/docs/home/architecture/security-models)
 - [When to use Plasma](https://docs.polygon.technology/docs/home/architecture/security-models)
-- [Moving assets from Mainchain to Polygon chain: the Plasma way](https://maticnetwork.github.io/matic.js/docs/)
+- [Moving assets from Mainchain to Polygon chain: the Plasma way](https://maticnetwork.github.io/matic.js/)
 - [Swapping Plasma Assets](https://docs.polygon.technology/docs/develop/advanced/swap-assets)
 
 **Other links**

--- a/docs/develop/network-details/gas-token.mdx
+++ b/docs/develop/network-details/gas-token.mdx
@@ -35,7 +35,7 @@ Ways to get matic token for Mumbai :
     - Enter your account address and confirm
 
 - If you want to interact Goerli ↔ Mumbai,
-    - You can use Maticjs : [https://maticnetwork.github.io/matic.js/docs/](https://maticnetwork.github.io/matic.js/docs/)
+    - You can use Maticjs : [https://maticnetwork.github.io/matic.js/](https://maticnetwork.github.io/matic.js/)
     - Or Use our new Polygon Web Wallet �: [https://wallet-dev.polygon.technology/](https://wallet-dev.polygon.technology/)
 
 </TabItem>
@@ -81,7 +81,7 @@ Getting the Matic token is really easy. You can deposit MATIC token from Goerli 
 - **Step 2: Deposit MATIC Token:**
     - You can deposit token using our wallet web,
         - (Recommended) Use new Polygon Web Wallet: [https://wallet.polygon.technology/](https://wallet.polygon.technology/)
-        - You can use Maticjs: [https://maticnetwork.github.io/matic.js/docs/](https://maticnetwork.github.io/matic.js/docs/)
+        - You can use Maticjs: [https://maticnetwork.github.io/matic.js/](https://maticnetwork.github.io/matic.js/)
 
   🎉Voila, you can start interacting with Polygon now 🎉
 


### PR DESCRIPTION
Change links in the documentation from https://maticnetwork.github.io/matic.js/docs/ to https://maticnetwork.github.io/matic.js/