### PR TITLE
Fixing incompatible solidity version

### DIFF
--- a/docs/develop/alchemy.md
+++ b/docs/develop/alchemy.md
@@ -282,7 +282,7 @@ require("@nomiclabs/hardhat-ethers");
 const { API_URL, PRIVATE_KEY } = process.env;
 
 module.exports = {
-   solidity: "0.7.3",
+   solidity: "0.8.9",
    defaultNetwork: "polygon_mumbai",
    networks: {
       hardhat: {},


### PR DESCRIPTION
The hello world example does not compile because the solidity version in `hardhat.config.js` is lower than in the example contract we're compiling.