### PR TITLE
docs(build): add descriptions for tutorials

### DIFF
--- a/docs/develop/graph.md
+++ b/docs/develop/graph.md
@@ -1,7 +1,7 @@
 ---
 id: graph
-title: Setting up hosted project with  TheGraph and Matic
-description: 
+title: Setting up hosted project with The Graph and Matic
+description: Learn how to set up a hosted project with The Graph and Matic.
 keywords:
   - graph
   - matic
@@ -10,7 +10,7 @@ image: https://matic.network/banners/matic-network-16x9.png
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-TheGraph, a decentralized protocol for indexing and querying chain data, supports the Matic chain. Data defined through subgraphs is easy to query and explore. Subgraphs can be created locally, or use a free hosted explorer for indexing and data display. 
+The Graph, a decentralized protocol for indexing and querying chain data, supports the Matic chain. Data defined through subgraphs is easy to query and explore. Subgraphs can be created locally, or use a free hosted explorer for indexing and data display. 
 
 > Note: See https://thegraph.com/docs/quick-start for more details, local installation and more. The docs include an example for learning how subgraphs work and this video provides a good introduction.
 
@@ -69,6 +69,3 @@ Your subgraph will be deployed and can be accessed from your dashboard.
 You can learn about querying the subgraph here: https://thegraph.com/docs/query-the-graph#using-the-graph-explorer
 
 If you want to make your subgraph public, you can do so by accessing your subgraph from your dashboard and then click on edit button. You will see the slider at the bottom of edit page.
-
-
-

--- a/docs/develop/nft-tutorial.md
+++ b/docs/develop/nft-tutorial.md
@@ -1,7 +1,7 @@
 ---
 id: nft-tutorial
 title: Polygon NFT Tutorial
-description:
+description: Build, mint, and send around your own ERC721 (NFT).
 keywords:
   - graph
   - matic

--- a/docs/develop/tools/graph.md
+++ b/docs/develop/tools/graph.md
@@ -1,7 +1,7 @@
 ---
 id: graph
-title: Setting up hosted project with  TheGraph and Polygon
-description: 
+title: Setting up a hosted project with The Graph and Polygon
+description: Learn how to set up a hosted project with The Graph and Polygon.
 keywords:
   - graph
   - matic
@@ -10,7 +10,7 @@ image: https://matic.network/banners/matic-network-16x9.png
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-TheGraph, a decentralized protocol for indexing and querying chain data, supports the Polygon chain. Data defined through subgraphs is easy to query and explore. Subgraphs can be created locally, or use a free hosted explorer for indexing and data display. 
+The Graph, a decentralized protocol for indexing and querying chain data, supports the Polygon chain. Data defined through subgraphs is easy to query and explore. Subgraphs can be created locally, or use a free hosted explorer for indexing and data display. 
 
 > Note: See https://thegraph.com/docs/quick-start for more details, local installation and more. The docs include an example for learning how subgraphs work and this video provides a good introduction.
 
@@ -69,6 +69,3 @@ Your subgraph will be deployed and can be accessed from your dashboard.
 You can learn about querying the subgraph here: https://thegraph.com/docs/query-the-graph#using-the-graph-explorer
 
 If you want to make your subgraph public, you can do so by accessing your subgraph from your dashboard and then click on edit button. You will see the slider at the bottom of edit page.
-
-
-

--- a/docs/develop/wallets/polygon-web-wallet/web-wallet-v2-guide.md
+++ b/docs/develop/wallets/polygon-web-wallet/web-wallet-v2-guide.md
@@ -1,7 +1,7 @@
 ---
 id: web-wallet-v2-guide
 title: Web Wallet Usage Guide
-description: 
+description: Learn how to use the Polygon Web Wallet.
 keywords:
   - wallet
   - matic
@@ -178,7 +178,4 @@ Once you have confirmed all these transactions, you will receive your funds back
 
 >Note: You can view the successful transactions after “Transfer in Progress/Action required” transactions in the “Action Required” popup.
 
-
 >Note: In case you any queries, feel free to raise a ticket here https://support.polygon.technology/support/home
-
-

--- a/docs/validate/validator/bridge.md
+++ b/docs/validate/validator/bridge.md
@@ -1,7 +1,7 @@
 ---
 id: bridge
 title: Bridge
-description: 
+description: Work In Progress
 keywords:
   - docs
   - matic


### PR DESCRIPTION
Running `yarn start` was producing errors for these markdown files that did not specify a `description`.

```
$ yarn start
yarn run v1.22.15
$ docusaurus start
[INFO] Starting the development server...
[ERROR] A validation error occurred.
[INFO] The validation system was added recently to Docusaurus as an attempt to avoid user configuration errors.
We may have made some mistakes.
If you think your configuration is valid and should keep working, please open a bug report.
[ERROR] The following front matter:
{
  "id": "graph",
  "title": "Setting up hosted project with  TheGraph and Polygon",
  "description": null,
  "keywords": [
    "graph",
    "matic"
  ],
  "image": "https://matic.network/banners/matic-network-16x9.png"
}
contains invalid values for field(s): description.

- "description" must be a string
```

The build would fail. But, now it doesn't! 🥂 