### PR TITLE
docs: remove features links from navbar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -162,34 +162,10 @@ module.exports = {
       },
       items: [
         {
-          to: "docs/home/new-to-polygon",
-          label: "Basics",
-          position: "left",
-          activeBasePath: "docs/home",
-        },
-        {
-          to: "docs/develop/getting-started",
-          label: "Develop",
-          position: "left",
-          activeBasePath: "docs/develop",
-        },
-        {
-          to: "docs/validate/polygon-overview",
-          label: "Validate",
-          position: "left",
-          activeBasePath: "docs/validate",
-        },
-        {
-          to: "docs/integrate/quickstart",
-          label: "Integrate",
-          position: "left",
-          activeBasePath: "docs/integrate",
-        },
-        {
-          to: "docs/contribute/orientation",
-          label: "Contribute",
-          position: "left",
-          activeBasePath: "docs/contribute",
+          to: "docs/faq/technical-faqs",
+          label: "FAQ",
+          position: "right",
+          activeBasePath: "docs/faq",
         },
         {
           label: "Support",
@@ -201,17 +177,6 @@ module.exports = {
           position: "right",
           className: "header-github-link",
           "aria-label": "GitHub repository",
-        },
-        {
-          label: "Polygon SDK",
-          href: "https://sdk-docs.polygon.technology/docs/overview/",
-          position: "left",
-        },
-        {
-          to: "docs/faq/technical-faqs",
-          label: "FAQ",
-          position: "left",
-          activeBasePath: "docs/faq",
         },
       ],
     },


### PR DESCRIPTION
⚠️ This could be somewhat contentious.

The gif below demonstrates a before / after for this change.

**Before** At certain resolutions, the links in the navbar ("Basics", "Develop", "Validate", ...) force the "Support", Search Bar, etc. to wrap to the next line.

**After** The feature links ("Basics", "Develop", "Validate", ...) are removed, leaving the "Help"-type links, "FAQ", "Support", and Search Bar.

![Screen Recording 2022-02-07 at 9 48 27 AM](https://user-images.githubusercontent.com/723048/152815400-d3b2b05a-dfe5-4fdf-9162-a5fbab4a5ce8.gif)

There are certainly other ways to solve the wrapping problem, but this turned out to have an added benefit, in my opinion. As an example, if a reader decides they want to learn the "Blockchain Basics", this is what they currently see after clicking the feature on the homepage:

![Screen Shot 2022-02-07 at 10 08 30 AM](https://user-images.githubusercontent.com/723048/152814652-bd3012f7-ffff-49a8-840f-5436207c911c.jpg)

This could be intimidating, as there is a bit of "link overload" before they even get to "What is a blockchain?" By removing the feature links in the navbar, it calms the page down a bit, letting the focus go to the content:

![Screen Shot 2022-02-07 at 10 10 10 AM](https://user-images.githubusercontent.com/723048/152814897-6928bc47-94ff-4256-979b-9870494f6adb.jpg)

This is just one option for solving the wrapping problem. I'm happy to try again if anyone has another idea 👍🏻 

Thanks! 🍻 