### PR TITLE
Added JSON-RPC Polygon methods to Polygon Docs

### DIFF
--- a/docs/develop/api-documentation/gettting-started.md
+++ b/docs/develop/api-documentation/gettting-started.md
@@ -1,5 +1,5 @@
 ---
-id: getting-started
+id: getting-started-rpc
 title: Getting Started with RPC API Methods
 ---
 

--- a/docs/develop/api-documentation/gettting-started.md
+++ b/docs/develop/api-documentation/gettting-started.md
@@ -3,14 +3,13 @@ id: getting-started-rpc
 title: Getting Started with RPC API Methods
 ---
 
-JSON-RPC is a stateless, light-weight remote procedure call (RPC) protocol that is commonly used for interacting with the Polygon network layer. As an integral part of the Blockchain Interaction Layer within the [Web3 ecosystem](https://blog.alchemy.com/blog/web3-stack/?a=matic-docs), Polygon JSON-RPC methods allow developers to query for data, write to the blockchain, and build dApps.
+JSON-RPC is a stateless, light-weight remote procedure call (RPC) protocol that is commonly used for interacting with the Polygon network layer. Polygon JSON-RPC methods allow developers to query for data, write to the blockchain, and build dApps.
 
 ## API Documentation
 
-To get started with the API, visit the complete set of API documentation for standard [Polygon JSON-RPC calls](https://docs.alchemy.com/alchemy/apis/polygon-api/?a=matic-docs).
+To get started with the API, visit the complete set of API documentation for standard [Polygon JSON-RPC calls](https://edge-docs.polygon.technology/docs/get-started/json-rpc-commands/).
 
 ## No-Code API Requests
 
-If you want to get started with API requests with no set-up, fix failing requests, or explore new methods on the Polygon network, try out the [Composer App](https://composer.alchemyapi.io?composer_state=%7B%22chain%22%3A2%2C%22network%22%3A401%2C%22methodName%22%3A%22eth_getBlockByNumber%22%2C%22paramValues%22%3A%5B%22latest%22%2Cfalse%5D%7D).
+If you want to get started with API requests that require no set-up, fix failing requests, or, explore new methods on the Polygon network, try out the [Composer App](https://composer.alchemyapi.io?composer_state=%7B%22chain%22%3A2%2C%22network%22%3A401%2C%22methodName%22%3A%22eth_getBlockByNumber%22%2C%22paramValues%22%3A%5B%22latest%22%2Cfalse%5D%7D).
 
-Composer allows developers to save hours of debugging and building time while also providing a friendly UI for sharing API calls.

--- a/docs/develop/api-documentation/gettting-started.md
+++ b/docs/develop/api-documentation/gettting-started.md
@@ -1,0 +1,16 @@
+---
+id: getting-started
+title: Getting Started with RPC API Methods
+---
+
+JSON-RPC is a stateless, light-weight remote procedure call (RPC) protocol that is commonly used for interacting with the Polygon network layer. As an integral part of the Blockchain Interaction Layer within the (Web3 ecosystem)[https://blog.alchemy.com/blog/web3-stack/?a=matic-docs], Polygon JSON-RPC methods allow developers to query for data, write to the blockchain, and build dApps.
+
+## API Documentation
+
+To get started with the API, (visit a complete set of API documentation for standard Polygon JSON-RPC calls)[https://docs.alchemy.com/alchemy/apis/polygon-api/?a=matic-docs].
+
+## No-Code API Requests
+
+If you want to get started with API requests with no set-up, fix failing requests, or explore new methods on the Polygon network, try out the (Composer App)[https://composer.alchemyapi.io?composer_state=%7B%22chain%22%3A2%2C%22network%22%3A401%2C%22methodName%22%3A%22eth_getBlockByNumber%22%2C%22paramValues%22%3A%5B%22latest%22%2Cfalse%5D%7D].
+
+Composer allows developers to save hours of debugging and building time while also providing a UI-friendly interface for sharing API calls with teammates!

--- a/docs/develop/api-documentation/gettting-started.md
+++ b/docs/develop/api-documentation/gettting-started.md
@@ -13,4 +13,4 @@ To get started with the API, [visit a complete set of API documentation for stan
 
 If you want to get started with API requests with no set-up, fix failing requests, or explore new methods on the Polygon network, try out the [Composer App](https://composer.alchemyapi.io?composer_state=%7B%22chain%22%3A2%2C%22network%22%3A401%2C%22methodName%22%3A%22eth_getBlockByNumber%22%2C%22paramValues%22%3A%5B%22latest%22%2Cfalse%5D%7D).
 
-Composer allows developers to save hours of debugging and building time while also providing a UI-friendly interface for sharing API calls with teammates!
+Composer allows developers to save hours of debugging and building time while also providing a friendly UI for sharing API calls.

--- a/docs/develop/api-documentation/gettting-started.md
+++ b/docs/develop/api-documentation/gettting-started.md
@@ -7,7 +7,7 @@ JSON-RPC is a stateless, light-weight remote procedure call (RPC) protocol that 
 
 ## API Documentation
 
-To get started with the API, [visit a complete set of API documentation for standard Polygon JSON-RPC calls](https://docs.alchemy.com/alchemy/apis/polygon-api/?a=matic-docs).
+To get started with the API, visit the complete set of API documentation for standard [Polygon JSON-RPC calls](https://docs.alchemy.com/alchemy/apis/polygon-api/?a=matic-docs).
 
 ## No-Code API Requests
 

--- a/docs/develop/api-documentation/gettting-started.md
+++ b/docs/develop/api-documentation/gettting-started.md
@@ -3,14 +3,14 @@ id: getting-started
 title: Getting Started with RPC API Methods
 ---
 
-JSON-RPC is a stateless, light-weight remote procedure call (RPC) protocol that is commonly used for interacting with the Polygon network layer. As an integral part of the Blockchain Interaction Layer within the (Web3 ecosystem)[https://blog.alchemy.com/blog/web3-stack/?a=matic-docs], Polygon JSON-RPC methods allow developers to query for data, write to the blockchain, and build dApps.
+JSON-RPC is a stateless, light-weight remote procedure call (RPC) protocol that is commonly used for interacting with the Polygon network layer. As an integral part of the Blockchain Interaction Layer within the [Web3 ecosystem](https://blog.alchemy.com/blog/web3-stack/?a=matic-docs), Polygon JSON-RPC methods allow developers to query for data, write to the blockchain, and build dApps.
 
 ## API Documentation
 
-To get started with the API, (visit a complete set of API documentation for standard Polygon JSON-RPC calls)[https://docs.alchemy.com/alchemy/apis/polygon-api/?a=matic-docs].
+To get started with the API, [visit a complete set of API documentation for standard Polygon JSON-RPC calls](https://docs.alchemy.com/alchemy/apis/polygon-api/?a=matic-docs).
 
 ## No-Code API Requests
 
-If you want to get started with API requests with no set-up, fix failing requests, or explore new methods on the Polygon network, try out the (Composer App)[https://composer.alchemyapi.io?composer_state=%7B%22chain%22%3A2%2C%22network%22%3A401%2C%22methodName%22%3A%22eth_getBlockByNumber%22%2C%22paramValues%22%3A%5B%22latest%22%2Cfalse%5D%7D].
+If you want to get started with API requests with no set-up, fix failing requests, or explore new methods on the Polygon network, try out the [Composer App](https://composer.alchemyapi.io?composer_state=%7B%22chain%22%3A2%2C%22network%22%3A401%2C%22methodName%22%3A%22eth_getBlockByNumber%22%2C%22paramValues%22%3A%5B%22latest%22%2Cfalse%5D%7D).
 
 Composer allows developers to save hours of debugging and building time while also providing a UI-friendly interface for sharing API calls with teammates!

--- a/sidebars.js
+++ b/sidebars.js
@@ -346,7 +346,7 @@ module.exports = {
     {
       type: "category",
       label: "API Documentation",
-      items: ["develop/api-documentation","develop/api-documentation/getting-started"]
+      items: ["develop/api-documentation/getting-started"]
     },
   ],
   Integrate: [

--- a/sidebars.js
+++ b/sidebars.js
@@ -346,7 +346,7 @@ module.exports = {
     {
       type: "category",
       label: "API Documentation",
-      items: ["develop/api-documentation/getting-started"]
+      items: ["develop/api-documentation/getting-started-rpc"]
     },
   ],
   Integrate: [

--- a/sidebars.js
+++ b/sidebars.js
@@ -343,6 +343,11 @@ module.exports = {
       label: "DID Implementation",
       items: ["develop/did-implementation/introduction","develop/did-implementation/getting-started"]
     },
+    {
+      type: "category",
+      label: "API Documentation",
+      items: ["develop/api-documentation","develop/api-documentation/getting-started"]
+    },
   ],
   Integrate: [
     "integrate/quickstart",


### PR DESCRIPTION
The current docs are missing links to RPC methods; added a JSON-RPC docs page and a few other getting-started guides