### PR TITLE
update foundry init

### DIFF
--- a/docs/develop/chainstack.md
+++ b/docs/develop/chainstack.md
@@ -32,9 +32,15 @@ Foundry is a development toolkit to work with smart contracts.
 
 ## Initialize with Foundry
 
-To create a boilerplate project, navigate to your project directory and run:
+To create a boilerplate project, navigate to your working directory and run:
 
-`foundry init`.
+``` sh
+forge init PROJECT_NAME
+```
+
+where
+
+* PROJECT_NAME - name of project
 
 ## Fund Your Account
 


### PR DESCRIPTION
To create a new boilerplate project with foundry, `forge init PROJECT_NAME` is used instead of `foundry init`.
It can be verified from [here](https://book.getfoundry.sh/projects/creating-a-new-project.html). 