### PR TITLE
Include all Products for Landing Page ReDesign

### DIFF
--- a/src/data/features.js
+++ b/src/data/features.js
@@ -1,15 +1,30 @@
 export const firstRow = [
     {
+        title: "Basics",
+        linkUrl: "docs/home/new-to-polygon",
+        imageUrl: "img/home/blockchain-basics.svg",
+        description: "Learn about the basics of Polygon."
+    },
+    {
+        title: "Validate",
+        linkUrl: "docs/contribute/orientation",
+        imageUrl: "img/home/core-contributors.svg",
+        description: "Learn how to stake and setup you own nodes to maintain the networks"
+    },
+    {
+        title: "Integrate",
+        linkUrl: "docs/contribute/orientation",
+        imageUrl: "img/home/core-contributors.svg",
+        description: "Learn about how to integrate with Polygon."
+    },
+];
+
+export const secondRow = [
+    {
         title: "Polygon PoS",
         linkUrl: "docs/home/new-to-polygon",
         imageUrl: "img/home/blockchain-basics.svg",
-        description: "Learn about Polygon PoS, how to develop Dapps, and how to become a validator"
-    },
-    {
-        title: "Polygon Nightfall",
-        linkUrl: "docs/nightfall/introduction/overview",
-        imageUrl: "docs/nightfall/imgs/Nightfall.png",
-        description: "Polygon Nightfall's main value proposition is to enable secure, private, and low-cost transfers of data in a decentralized network."
+        description: "An EVM compatible Ethereum sidechain that follows delegated proof of stake."
     },
     {
         title: "Polygon Edge",
@@ -18,31 +33,54 @@ export const firstRow = [
         imageUrl: "img/home/polygon-sdk.svg",
         description: "A modular and extensible framework for building Ethereum-compatible blockchain networks."
     },
-
-];
-
-export const secondRow = [
     {
-        title: "Validators",
-        linkUrl: "docs/maintain/polygon-basics/who-is-validator",
-        imageUrl: "img/home/core-contribution.svg",
-        description: 'Learn how to stake with Polygon, and setup you own nodes to maintain the network and earn rewards'
+        title: "Polygon Supernets",
+        linkUrl: "docs/nightfall/introduction/overview",
+        imageUrl: "docs/nightfall/imgs/Nightfall.png",
+        description: "Application-specific chains that are interoperable, scalable & secure, powered by Polygon Edge."
     },
-    {
-        title: "Integration ",
-        linkUrl: "docs/integrate/quickstart",
-        imageUrl: "img/home/integration.svg",
-        description: "Key information for projects looking to integrate with Polygon. Wallets, developer tools, oracles and more - get all the info you need"
-    },
-    {
-        title: "Core Contributors",
-        linkUrl: "docs/contribute/orientation",
-        imageUrl: "img/home/core-contributors.svg",
-        description: "Contribute and get involved with the Polygon code base. Spin up a local testnet, or just submit a Pull Request on one of our repos"
-    }
 ];
 
 export const thirdRow = [
+    {
+        title: "Polygon Avail",
+        linkUrl: "docs/maintain/polygon-basics/who-is-validator",
+        imageUrl: "img/home/core-contribution.svg",
+        description: 'A general-purpose, scalable, data availability-focused blockchain.'
+    },
+    {
+        title: "Polygon Hermez",
+        linkUrl: "docs/nightfall/introduction/overview",
+        imageUrl: "docs/nightfall/imgs/Nightfall.png",
+        description: "A zk-rollup solution for scaling payments and token transfers."
+    },
+    {
+        title: "Polygon Zero",
+        linkUrl: "docs/nightfall/introduction/overview",
+        imageUrl: "docs/nightfall/imgs/Nightfall.png",
+        description: "A highly scalable, Ethereum-compatiable zk-rollup."
+    },
+    {
+        title: "Polygon Miden",
+        linkUrl: "docs/nightfall/introduction/overview",
+        imageUrl: "docs/nightfall/imgs/Nightfall.png",
+        description: "A STARK-based zk-rollup solution that supports arbitrary smart contracts"
+    },
+    {
+        title: "Polygon Nightfall",
+        linkUrl: "docs/maintain/polygon-basics/who-is-validator",
+        imageUrl: "img/home/core-contribution.svg",
+        description: 'The first rollup solution designed for enterprises that supports private transactions'
+    },
+    {
+        title: "Polygon ID",
+        linkUrl: "docs/integrate/quickstart",
+        imageUrl: "img/home/integration.svg",
+        description: "A blockchain-native identity and authentication solution."
+    },
+];
+
+export const FourthRow = [
     {
         title: "Key Management",
         // imageUrl: [{card:"img/basic.svg" , basic:"img/basic.svg"}],

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -5,7 +5,7 @@ import Link from "@docusaurus/Link";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import useBaseUrl from "@docusaurus/useBaseUrl";
 import styles from "./styles.module.css";
-import { firstRow, secondRow, networkBanner } from "../data/features";
+import { firstRow, secondRow, thirdRow, networkBanner } from "../data/features";
 import SearchBar from '@theme-original/SearchBar';
 
 function NetworkBanner({title, class_name, description, linkUrl, imageUrl}) {
@@ -45,6 +45,8 @@ function FirstRow({ title, description, linkUrl, imageUrl }) {
   );
 }
 
+
+
 function SecondRow({ title, description, linkUrl, imageUrl }) {
   // const imgUrl = useBaseUrl(imageUrl);
   return (
@@ -62,6 +64,25 @@ function SecondRow({ title, description, linkUrl, imageUrl }) {
   );
 }
 
+function ThirdRow({ title, description, linkUrl, imageUrl }) {
+  // const imgUrl = useBaseUrl(imageUrl);
+  return (
+
+    <div className="col-md-4 p-8">
+      <Link to={useBaseUrl(linkUrl)} activeClassName="active">
+        <div className="show-card">
+          <div className="icon-wrapper">
+            <img src={useBaseUrl(imageUrl)} alt={title} className="icon" />
+          </div>
+          <div className="title">{title}</div>
+          <div className="descriptions">{description}</div>
+        </div>
+      </Link>
+    </div>
+
+  );
+}
+
 function Home() {
   const context = useDocusaurusContext();
   const { siteConfig = {} } = context;
@@ -69,8 +90,8 @@ function Home() {
     <Layout>
       <div
         className="bootstrap-wrapper"
-      >
-        <h1 align="center" style={{ fontWeight: '600' }}> Welcome to the Docs of all Polygon Products</h1>
+      >        
+        <h1 align="center" style={{ fontWeight: '600' }}> The Official Polygon Docs</h1>
           <body>
            <center>
             <SearchBar/>{' '}
@@ -98,6 +119,13 @@ function Home() {
               secondRow.map((props, idx) => (
                 <SecondRow key={idx} {...props} />
               ))}{" "}
+          <div className="row">
+            {thirdRow &&
+              thirdRow.length &&
+              thirdRow.map((props, idx) => (
+                <ThirdRow key={idx} {...props} />
+              ))}{" "}
+          </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
As the approach is to redesign, all products should be included.

This should serve as a draft for the intent of the design as it should be discussed. Images and the rest will be updated after.
It would also be good if we can determine a way to organize the blocks on the landing page in regards to the suite of products, even though all can be considered "scaling solutions" other than Polygon ID. However, we can have a labels for the specific type of products

Some names that come to mind are: "Rollups" or "Rollup" as a verb, "Enterprise" or "Build" as a verb, etc.

Still, this is an opportunity to enhance the UI/UX and we should consider updating the JS