### PR TITLE
Update node version from 14 to 14.13.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       # Setup node with version 12.x and NPM registry url
       - uses: actions/setup-node@v1
         with:
-          node-version: "14.0"
+          node-version: "14.13.1"
       # Run npm install to install project packages
       - run: yarn install --frozen-lockfile
       # npm run build to build the project


### PR DESCRIPTION
Follows: https://github.com/maticnetwork/matic-docs/pull/894

```
The engine "node" is incompatible with this module. Expected version "^12.20.0 || ^14.13.1 || >=16.0.0". Got "14.0.0"
```