### PR TITLE
renamed nightfall.png

### DIFF
--- a/src/data/features.js
+++ b/src/data/features.js
@@ -80,7 +80,7 @@ export const secondRow = [
         title: "Nightfall",
         status: "Optimistic Rollup",
         linkUrl: "docs/nightfall/introduction/overview",
-        imageUrl: "img/nightfall.png",
+        imageUrl: "img/Nightfall.png",
         description: "An optimistic rollup solution designed for enterprises that supports private transactions."
     },
     {


### PR DESCRIPTION
Used uppercase on the features.js. Ideally, we should rename Nightfall.png to nightfall.png and keep the features.js file referring to it using lowercase. However, I couldn't generate a commit just by changing the filename. SO I had to do the other way around, meaning, I used uppercase on features.js.