### PR TITLE
Point the block explorer the right URL

### DIFF
--- a/docs/develop/network-details/network.md
+++ b/docs/develop/network-details/network.md
@@ -74,7 +74,7 @@ The native token of the Polygon PoS is MATIC and is used for gas.
 | RPC Endpoint                       | [https://polygon-rpc.com/](https://polygon-rpc.com/)                     | 
 | Node Endpoint                      | [wss://rpc-mainnet.matic.network](wss://rpc-mainnet.matic.network)       |
 | Heimdall API                       | [https://heimdall.api.matic.network](https://heimdall.api.matic.network) |
-| Block Explorer                     | [https://mumbai.polygonscan.com/](https://mumbai.polygonscan.com/)       |
+| Block Explorer                     | [https://polygonscan.com/](https://polygonscan.com/)       |
 
 :::note More details 
 


### PR DESCRIPTION
The block explorer URL under Polygon PoS Mainnet was referring to the mumbai testnet block explorer.