### PR TITLE
Update /docs/develop/network-details/full-node-docker.md

### DIFF
--- a/docs/develop/network-details/full-node-docker.md
+++ b/docs/develop/network-details/full-node-docker.md
@@ -175,7 +175,7 @@ laddr = "tcp://0.0.0.0:26657"
 seeds="f4f605d60b8ffaaf15240564e58a81103510631c@159.203.9.164:26656,4fb1bc820088764a564d4f66bba1963d47d82329@44.232.55.71:26656,2eadba4be3ce47ac8db0a3538cb923b57b41c927@35.199.4.13:26656,3b23b20017a6f348d329c102ddc0088f0a10a444@35.221.13.28:26656,25f5f65a09c56e9f1d2d90618aa70cd358aa68da@35.230.116.151:26656"
 ```
 
-Now that your `onfig.toml` file is all set, you’ll need to make two small changes to your `heimdall-config.toml` file. Use your favorite editor to update these two settings:
+Now that your `config.toml` file is all set, you’ll need to make two small changes to your `heimdall-config.toml` file. Use your favorite editor to update these two settings:
 
 ```
 # RPC endpoint for ethereum chain
@@ -471,7 +471,7 @@ docker exec -it bor /bin/sh
 bor attach /bor-home/bor.ipc
 
 # now we can run eth.syncing to see what's going on
-eth.sycning
+eth.syncing
 ```
 
 This will give you some output to give you a sense of the current progress.


### PR DESCRIPTION
Fix a typo referencing the `config.toml` for Heimdall
Fix a typo in the `eth.syncing` command for Bor