### PR TITLE
fix: typo in syncer.md

### DIFF
--- a/docs/edge/architecture/modules/syncer.md
+++ b/docs/edge/architecture/modules/syncer.md
@@ -56,9 +56,9 @@ This is the flow of the Watch Sync process:
 Performance was measured on a local machine by syncing a ** million blocks **
 :::
 
-| Name                 | Result         |
-|----------------------|----------------|
-| Syncing 1M blocks    | ~ 25 min       | 
-| Tranfering 1M blocks | ~ 1 min        | 
-| Number of GRPC calls | 2              |
-| Test coverage        | ~ 93%          |
+| Name                   | Result         |
+|------------------------|----------------|
+| Syncing 1M blocks      | ~ 25 min       | 
+| Transferring 1M blocks | ~ 1 min        | 
+| Number of GRPC calls   | 2              |
+| Test coverage          | ~ 93%          |


### PR DESCRIPTION
Fix typo: tranfering -> transferring on L:62