### PR TITLE
Update /docs/maintain/validate/faq/validator-faq

### DIFF
--- a/docs/maintain/polygon-basics/who-is-validator.md
+++ b/docs/maintain/polygon-basics/who-is-validator.md
@@ -18,20 +18,20 @@ Rewards are distributed to all stakers proportional to their stake at every chec
 Stakes are at risk of getting slashed in case the validator node commits a malicious act like double signing which also affects the linked delegators at that checkpoint.
 
 :::note
-Those who are interested in securing the network but are not running a full node can participate as [delegators](../glossary#delegator).
+Those who are interested in securing the network but are not running a full node can participate as [delegators](/docs/maintain/glossary#delegator).
 :::
 
 ## Overview
 
-Validators on the Polygon network are selected through an on-chain auction process which happens at regular intervals. These selected validators participate as block producers and verifiers. Once a [checkpoint](../glossary#checkpoint-transaction) is validated by the participants, updates are made on the parent chain (the Ethereum mainnet) which releases the rewards for validators depending on their stake in network.
+Validators on the Polygon network are selected through an on-chain auction process which happens at regular intervals. These selected validators participate as block producers and verifiers. Once a [checkpoint](/docs/maintain/glossary#checkpoint-transaction) is validated by the participants, updates are made on the parent chain (the Ethereum mainnet) which releases the rewards for validators depending on their stake in network.
 
-Polygon relies on a set of [validators](../glossary#validator) to secure the network. The role of validators is to run a full node, [produce blocks](../glossary#block-producer), validate and participate in consensus, and commit [checkpoints](../glossary#checkpoint-transaction) on the Ethereum mainnet. To become a validator, one needs to [stake](../glossary#staking) their MATIC tokens with staking management contracts residing on the Ethereum mainnet.
+Polygon relies on a set of [validators](/docs/maintain/glossary#validator) to secure the network. The role of validators is to run a full node, [produce blocks](/docs/maintain/glossary#block-producer), validate and participate in consensus, and commit [checkpoints](/docs/maintain/glossary#checkpoint-transaction) on the Ethereum mainnet. To become a validator, one needs to [stake](/docs/maintain/glossary#staking) their MATIC tokens with staking management contracts residing on the Ethereum mainnet.
 
 ## Core components
 
-[Heimdall](../glossary#heimdall) reads the events emitted by the staking contracts to pick the validators for the current set with their updated stake ratio, which is used also by [Bor](../glossary#bor) while producing blocks.
+[Heimdall](/docs/maintain/glossary#heimdall) reads the events emitted by the staking contracts to pick the validators for the current set with their updated stake ratio, which is used also by [Bor](/docs/maintain/glossary#bor) while producing blocks.
 
-[Delegation](../glossary#delegator) is also recorded in the staking contracts and any update in the validator power or node [signer address](../glossary#signer-address) or unbonding requests comes into effect when the next checkpoint gets committed.
+[Delegation](/docs/maintain/glossary#delegator) is also recorded in the staking contracts and any update in the validator power or node [signer address](/docs/maintain/glossary#signer-address) or unbonding requests comes into effect when the next checkpoint gets committed.
 
 
 ## End-to-end flow for a Polygon validator
@@ -42,11 +42,11 @@ Validators set up their signing nodes, sync data and then stake their tokens on 
 There is limited space for accepting new validators. New validators can only join the active set when a currently active validator unbonds. A new auction process for validator replacement will be rolled out.
 :::
 
-Block producers are chosen from the validator set where it is the responsibility of the selected validators to produce blocks for a given [span](../glossary#span).
+Block producers are chosen from the validator set where it is the responsibility of the selected validators to produce blocks for a given [span](/docs/maintain/glossary#span).
 
 Nodes at Heimdall validate the blocks being produced, participate in consensus and commit checkpoints on the Ethereum mainnet at defined intervals.
 
-The probability of validators to get selected as the block producer or checkpoint [proposer](../glossary#proposer) is dependent on one’s stake ratio including delegations in the overall pool.
+The probability of validators to get selected as the block producer or checkpoint [proposer](/docs/maintain/glossary#proposer) is dependent on one’s stake ratio including delegations in the overall pool.
 
 Validators receive rewards at every checkpoint as per their stake ratio, after deducting the proposer bonus which is disbursed to the checkpoint proposer.
 
@@ -58,10 +58,10 @@ See [Rewards](/docs/maintain/validator/rewards).
 
 ## Setting up a validator node
 
-See [Validate](../validate/validator-index).
+See [Validate](/docs/maintain/validate/validator-index).
 
 ## See also
 
-* [Validator Responsibilities](../validate/validator-responsibilities)
-* [Validate](../validate/validator-index)
-* [Validator FAQ](../validate/faq/validator-faq)
+* [Validator Responsibilities](/docs/maintain/validate/validator-responsibilities)
+* [Validate](/docs/maintain/validate/validator-index)
+* [Validator FAQ](/docs/maintain/validate/faq/validator-faq)


### PR DESCRIPTION
Most links seem to be broken due to invalid paths and result in "Page Not Found". See https://wiki.polygon.technology/docs/maintain/polygon-basics/who-is-validator/.

This PR updates link paths.

