### PR TITLE
[Documentation] Update possible typo in Glossary

### DIFF
--- a/docs/maintain/glossary.md
+++ b/docs/maintain/glossary.md
@@ -103,7 +103,7 @@ See also [Key Management](validator/core-components/key-management.md).
 
 ## Validator
 
-Validators stake their tokens on the Ethereum mainnet staking contracts and is running both the [Heimdall](#heimdall) node and the [Bor](#bor) node to commit the network checkpoints to the Ethereum mainnet and to produce blocks on the network.
+Validators [stake their MATIC tokens](/docs/maintain/validate/validator-staking-operations) via staking contracts deployed on the Ethereum mainnet and are running both the [Heimdall](#heimdall) node and the [Bor](#bor) node to commit the network checkpoints to the Ethereum mainnet and to produce blocks on the network.
 
 A validator node is only open to its [sentry](#sentry) node and closed to the rest of the network.
 

--- a/docs/maintain/glossary.md
+++ b/docs/maintain/glossary.md
@@ -103,7 +103,7 @@ See also [Key Management](validator/core-components/key-management.md).
 
 ## Validator
 
-The validator role stakes the MATIC tokens and is running both the [Heimdall](#heimdall) node and the [Bor](#bor) node to commit the network checkpoints to the Ethereum mainnet and to produce blocks on the network.
+Validators stake their tokens on the Ethereum mainnet staking contracts and is running both the [Heimdall](#heimdall) node and the [Bor](#bor) node to commit the network checkpoints to the Ethereum mainnet and to produce blocks on the network.
 
 A validator node is only open to its [sentry](#sentry) node and closed to the rest of the network.
 


### PR DESCRIPTION
This PR aims to fix a possible typo in the Glossary section and explicitly clarifies that the tokens will be staked on the Ethereum mainnet.