### PR TITLE
Modifying Polygon Edge docs

### DIFF
--- a/docs/edge/configuration/prometheus-metrics.md
+++ b/docs/edge/configuration/prometheus-metrics.md
@@ -34,4 +34,4 @@ The following metrics are available:
 | edge_network_inbound_connections_count          | Gauge    | Number of inbound connections               |
 | edge_network_pending_inbound_connections_count  | Gauge    | Number of pending outbound connections      |
 | edge_network_pending_outbound_connections_count | Gauge    | Number of pending inbound connections       |
- | edge_consensus_epoch_number                     | Gauge    | Current epoch number                        |
+| edge_consensus_epoch_number                     | Gauge    | Current epoch number                        |

--- a/docs/edge/configuration/prometheus-metrics.md
+++ b/docs/edge/configuration/prometheus-metrics.md
@@ -14,22 +14,24 @@ keywords:
 
 Polygon Edge can report and serve the Prometheus metrics, which in their turn can be consumed using Prometheus collector(s).
 
-Prometheus metrics are disabled by default. It can be enabled by specifying the listener address using `--prometheus` flag or `Telemetry.prometheus` field in the config file. 
+Prometheus metrics are disabled by default. 
+It can be enabled by specifying the listener address using `--prometheus` [flag](/docs/edge/get-started/cli-commands#prometheus) or `Telemetry.prometheus` field in the config file. 
 Metrics will be served under `/metrics` on the specified address.
 
 ## Available metrics
 
 The following metrics are available:
 
-| **Name**                                      | **Type**      | **Description**                                 |
-|-----------------------------------------------|---------------|-------------------------------------------------|
-| txpool_pending_transactions                   | Gauge         | Number of pending transactions in TxPool        |
-| consensus_validators                          | Gauge         | Number of Validators                            |
-| consensus_rounds                              | Gauge         | Number of Rounds                                |
-| consensus_num_txs                             | Gauge         | Number of Transactions in the latest block      |
-| consensus_block_interval                      | Gauge         | Time between this and last block in seconds     |
-| network_peers                                 | Gauge         | Number of Connected peers                       |
-| network_outbound_connections_count            | Gauge         | Number of outbound connections                  |
-| network_inbound_connections_count             | Gauge         | Number of inbound connections                   |
-| network_pending_outbound_connections_count    | Gauge         | Number of pending outbound connections          |
-| network_pending_inbound_connections_count     | Gauge         | Number of pending inbound connections           |
+| **Name**                                        | **Type** | **Description**                             |
+|-------------------------------------------------|----------|---------------------------------------------|
+| edge_txpool_pending_transactions                | Gauge    | Number of pending transactions in TxPool    |
+| edge_consensus_validators                       | Gauge    | Number of Validators                        |
+| edge_consensus_rounds                           | Gauge    | Number of Rounds                            |
+| edge_consensus_num_txs                          | Gauge    | Number of Transactions in the latest block  |
+| edge_consensus_block_interval                   | Gauge    | Time between this and last block in seconds |
+| edge_network_peers                              | Gauge    | Number of Connected peers                   |
+| edge_network_outbound_connections_count         | Gauge    | Number of outbound connections              |
+| edge_network_inbound_connections_count          | Gauge    | Number of inbound connections               |
+| edge_network_pending_inbound_connections_count  | Gauge    | Number of pending outbound connections      |
+| edge_network_pending_outbound_connections_count | Gauge    | Number of pending inbound connections       |
+ | edge_consensus_epoch_number                     | Gauge    | Current epoch number                        |

--- a/docs/edge/get-started/cli-commands.md
+++ b/docs/edge/get-started/cli-commands.md
@@ -108,7 +108,8 @@ Default address: `0.0.0.0:8545`.
   </TabItem>
 </Tabs>
 
-Sets the maximum block range to be considered when executing json-rpc requests that include fromBlock/toBlock values (e.g. eth_getLogs). Default:`1000`.
+Sets the maximum block range to be considered when executing json-rpc requests that include fromBlock/toBlock values (e.g. eth_getLogs).  
+This limit can be completely disabled by setting the value to `0`. Default:`1000`.
 
 ---
 
@@ -127,7 +128,8 @@ Sets the maximum block range to be considered when executing json-rpc requests t
   </TabItem>
 </Tabs>
 
-Sets the maximum length to be considered when handling json-rpc batch requests. Default: `20`.
+Sets the maximum length to be considered when handling json-rpc batch requests.
+This limit can be completely disabled by setting the value to `0`. Default: `20`.
 
 ---
 

--- a/docs/edge/get-started/set-up-ibft-on-the-cloud.md
+++ b/docs/edge/get-started/set-up-ibft-on-the-cloud.md
@@ -209,105 +209,48 @@ To do so, you can use the flag `--block-gas-limit` followed by the desired value
 
 :::info Set system file descriptor limit
 
-The default file descriptor limit ( maximum number of open files ) on some operating systems is pretty small.
-If the nodes are expected to have high throughput, you might consider increasing this limit on the OS level.
+The default file descriptor limit (maximum number of open files) can be low, and on Linux, everything is a file.
+If the nodes are expected to have high throughput, you might consider increasing this limit.
+Check the official docs of your linux distro for more details.
 
-For Ubuntu distro the procedure is as follows ( if you're not using Ubuntu/Debian distro, check the official docs for your OS ) :
--	Check current os limits ( open files )
-```shell title="ulimit -a"
-ubuntu@ubuntu:~$ ulimit -a
-core file size          (blocks, -c) 0
-data seg size           (kbytes, -d) unlimited
-scheduling priority             (-e) 0
-file size               (blocks, -f) unlimited
-pending signals                 (-i) 15391
-max locked memory       (kbytes, -l) 65536
-max memory size         (kbytes, -m) unlimited
-open files                      (-n) 1024
-pipe size            (512 bytes, -p) 8
-POSIX message queues     (bytes, -q) 819200
-real-time priority              (-r) 0
-stack size              (kbytes, -s) 8192
-cpu time               (seconds, -t) unlimited
-max user processes              (-u) 15391
-virtual memory          (kbytes, -v) unlimited
-file locks                      (-x) unlimited
+#### Check current os limits ( open files )
+```shell title="ulimit -n"
+1024 # Ubuntu default
 ```
 
-- Increase open files limit
-	- Localy - affects only current session:
-	```shell
-	ulimit -u 65535
-	```
-	- Globaly or per user ( add limits at the end of /etc/security/limits.conf file ) :
-	```shell 
-	sudo vi /etc/security/limits.conf  # we use vi, but you can use your favorite text editor
-	```
-	```shell title="/etc/security/limits.conf"
-	# /etc/security/limits.conf
-	#
-	#Each line describes a limit for a user in the form:
-	#
-	#<domain>        <type>  <item>  <value>
-	#
-	#Where:
-	#<domain> can be:
-	#        - a user name
-	#        - a group name, with @group syntax
-	#        - the wildcard *, for default entry
-	#        - the wildcard %, can be also used with %group syntax,
-	#                 for maxlogin limit
-	#        - NOTE: group and wildcard limits are not applied to root.
-	#          To apply a limit to the root user, <domain> must be
-	#          the literal username root.
-	#
-	#<type> can have the two values:
-	#        - "soft" for enforcing the soft limits
-	#        - "hard" for enforcing hard limits
-	#
-	#<item> can be one of the following:
-	#        - core - limits the core file size (KB)
-	#        - data - max data size (KB)
-	#        - fsize - maximum filesize (KB)
-	#        - memlock - max locked-in-memory address space (KB)
-	#        - nofile - max number of open file descriptors
-	#        - rss - max resident set size (KB)
-	#        - stack - max stack size (KB)
-	#        - cpu - max CPU time (MIN)
-	#        - nproc - max number of processes
-	#        - as - address space limit (KB)
-	#        - maxlogins - max number of logins for this user
+#### Increase open files limit
+- Running `polygon-edge` in foreground (shell)
+  ```shell title="Set FD limit for the current session"
+  ulimit -n 65535 # affects only current session, limit won't persist after logging out
+  ```
+  
+  ```shell title="Edit /etc/security/limits.conf"
+  # add the following lines to the end of the file to modify FD limits
+  *               soft    nofile          65535 # sets FD soft limit for all users
+  *               hard    nofile          65535 # sets FD hard limit for all users
 
-	#        - maxsyslogins - max number of logins on the system
-	#        - priority - the priority to run user process with
-	#        - locks - max number of file locks the user can hold
-	#        - sigpending - max number of pending signals
-	#        - msgqueue - max memory used by POSIX message queues (bytes)
-	#        - nice - max nice priority allowed to raise to values: [-20, 19]
-	#        - rtprio - max realtime priority
-	#        - chroot - change root to directory (Debian-specific)
-	#
-	#<domain>      <type>  <item>         <value>
-	#
+  # End of file
+  ```
+  Save the file and restart the system.
 
-	#*               soft    core            0
-	#root            hard    core            100000
-	#*               hard    rss             10000
-	#@student        hard    nproc           20
-	#@faculty        soft    nproc           20
-	#@faculty        hard    nproc           50
-	#ftp             hard    nproc           0
-	#ftp             -       chroot          /ftp
-	#@student        -       maxlogins       4
+- Running `polygon-edge` in the background as a service        
 
-	*               soft    nofile          65535
-	*               hard    nofile          65535
+  If `polygon-edge` is run as a system service, using the tool like `systemd`, file descriptor limits
+  should be managed using `systemd`. 
+  ```shell title="Edit /etc/systemd/system/polygon-edge.service"
+  [Service]
+   ...
+  LimitNOFILE=65535
+  ```
 
-	# End of file
-	```
-	Optionaly, modify additional parameters, save the file and restart the system.
-	After restart check file descriptor limit again.
-	It should be set to the value you defined in limits.conf file.
+### Troubleshooting
+```shell title="Watch FD limits of polygon edge running process"
+watch -n 1 "ls /proc/$(pidof polygon-edge)/fd | wc -l"
+```
+
+```shell title="Check max FD limits for polygon-edge running process"
+cat /proc/$(pidof polygon-edge)/limits
+```
 :::
 
 After specifying the:


### PR DESCRIPTION
This PR modifies the following content in the Polygon Edge section of the docs:
* CLI - `jsonrpc-batch-limits` - added info on how to disable the limits
* Local and Cloud setup - modified the section on file descriptors, how to set it properly when `polygon-edge` is running as a service
* Prometheus metrics - updated metrics to reflect the current codebase