### PR TITLE
Fix QuickNode LP link in docusaurus.config.js

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -733,7 +733,7 @@ module.exports = {
               "rel": null
             },
             {
-              "href": "https://www.quicknode.com/chains/polygon",
+              "href": "https://www.quicknode.com/chains/matic",
               "label": "QuickNode",
               "target": "_blank",
               "rel": null


### PR DESCRIPTION
### Fix QuickNode LP link in docusaurus.config.js

This PR updates the link to the QuickNode Polygon page. The current one is linked to a 404 page. The LP link is surfaced in the header via dropdown.