### PR TITLE
Resolve code block white-space formatting issue

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1889,7 +1889,7 @@ code {
   color: #F8F8F8;
   padding: 0.2em 0.4em;
   border-radius: 4px;
-  white-space: nowrap;
+  white-space: pre;
   font-weight: normal;
 }
 


### PR DESCRIPTION
Using your docs in both `Chromium 111.0.5563.64` and `Firefox 111.0`, every example code block was lacking formatting due to a CSS `white-space` issue.

![Screenshot from 2023-06-07 08-02-02](https://github.com/maticnetwork/matic-docs/assets/4543390/450d73cc-a1fc-4f8a-b9b1-6e766e107d5b)
![Screenshot from 2023-06-07 08-01-09](https://github.com/maticnetwork/matic-docs/assets/4543390/0e958075-2dec-4453-bf18-8e0bf1796d24)

Fixed on desktop and mobile, with overflow behaving as expected on mobile.

![Screenshot from 2023-06-07 08-02-40](https://github.com/maticnetwork/matic-docs/assets/4543390/c52d94bb-d9bd-430f-b6a4-c03deef6f21f)
![Screenshot from 2023-06-07 08-03-27](https://github.com/maticnetwork/matic-docs/assets/4543390/0a9ff596-2b1b-4e03-a500-0e8dc94072de)
