### PR TITLE
stake-manager-deploy fix

### DIFF
--- a/docs/supernets/operate/deploy/rootchain-config.md
+++ b/docs/supernets/operate/deploy/rootchain-config.md
@@ -399,7 +399,7 @@ This command includes a test flag, which is intended solely for testing scenario
   ./polygon-edge polybft stake-manager-deploy \
   --deployer-key <hex_encoded_rootchain_account_private_key> \
   [--genesis ./genesis.json] \
-  [--json-rpc http://127.0.0.1:8545] \
+  [--jsonrpc http://127.0.0.1:8545] \
   [--stake-token 0xaddressOfStakeToken] \
   [--test]
   ```

--- a/docs/supernets/operate/deploy/rootchain-config.md
+++ b/docs/supernets/operate/deploy/rootchain-config.md
@@ -172,18 +172,21 @@ If the `StakeManager` hasn't been deployed to the rootchain, you need to carry o
 <details>
 <summary>Flags ↓</summary>
 
-| Flag                   | Description                                                                      | Example |
-|------------------------|----------------------------------------------------------------------------------|---------|
-| `register-validator`   | Registers a whitelisted validator to supernet manager on rootchain               | `register-validator --validator-address 0xB16D...8DAB` |
-| `stake`                | Stakes the amount sent for validator on rootchain                                | `stake --amount 1000 --validator 0xB16D...8DAB` |
-| `stake-manager-deploy` | Command for deploying stake manager contract on rootchain                        | `--` |
-| `supernet`             | Performs supernet initialization & finalization command                          | `--` |
-| `unstake`              | Unstakes the amount sent for validator or undelegates amount from validator      | `unstake --validator 0xB16D...8DAB` |
-| `validator-info`       | Retrieves validator information                                                  | `validator-info --validator 0xB16D...8DAB` |
-| `whitelist-validators` | Whitelists new validators                                                        | `whitelist-validators --validator-address 0xB16D...8DAB` |
-| `withdraw-child`       | Withdraws pending withdrawals on child chain for a given validator               | `withdraw-child --validator 0xB16D...8DAB` |
-| `withdraw-rewards`     | Withdraws pending rewards on child chain for a given validator                   | `withdraw-rewards --validator 0xB16D...8DAB` |
-| `withdraw-root`        | Withdraws sender's withdrawable amount to a specified address on the root chain  | `withdraw-root --address 0xB16D...8DAB` |
+| Flag            | Description                                                                                            | Example |
+|-----------------|--------------------------------------------------------------------------------------------------------|---------|
+| `--config`      | Path to the SecretsManager config file, if omitted, the local FS secrets manager is used               |         |
+| `--data-dir`    | Directory for the Polygon Edge data if the local FS is used                                            |         |
+| `--genesis`     | Genesis file path, which contains chain configuration (default "./genesis.json")                       |         |
+| `--jsonrpc`     | The JSON-RPC interface (default "0.0.0.0:8545")                                                        |         |
+| `--private-key` | Hex-encoded private key of the account which executes rootchain commands                               |         |
+| `--stake-token` | Address of ERC20 token used for staking on rootchain                                                   |         |
+| `--test`        | Contract will be deployed using test account and a test stake ERC20 token will be deployed for staking |         |
+
+**Global Flags:**
+
+| Flag      | Description                                     | Example           |
+|-----------|-------------------------------------------------|-------------------|
+| `--json`  | Get all outputs in JSON format (default false). | `--json`          |
 
 </details>
 
@@ -407,17 +410,21 @@ This command includes a test flag, which is intended solely for testing scenario
 <details>
 <summary>Flags ↓</summary>
 
-| Flag                   | Description                                                                      | Example |
-|------------------------|----------------------------------------------------------------------------------|---------|
-| `register-validator`   | Registers a whitelisted validator to supernet manager on rootchain               | `register-validator --validator-address 0xB16D...8DAB` |
-| `stake`                | Stakes the amount sent for validator on rootchain                                | `stake --amount 1000 --validator 0xB16D...8DAB` |
-| `supernet`             | Performs supernet initialization & finalization command                          | `--` |
-| `unstake`              | Unstakes the amount sent for validator or undelegates amount from validator      | `unstake --validator 0xB16D...8DAB` |
-| `validator-info`       | Retrieves validator information                                                  | `validator-info --validator 0xB16D...8DAB` |
-| `whitelist-validators` | Whitelists new validators                                                        | `whitelist-validators --validator-address 0xB16D...8DAB` |
-| `withdraw-child`       | Withdraws pending withdrawals on child chain for a given validator               | `withdraw-child --validator 0xB16D...8DAB` |
-| `withdraw-rewards`     | Withdraws pending rewards on child chain for a given validator                   | `withdraw-rewards --validator 0xB16D...8DAB` |
-| `withdraw-root`        | Withdraws sender's withdrawable amount to a specified address on the root chain  | `withdraw-root --address 0xB16D...8DAB` |
+| Flag            | Description                                                                                            | Example |
+|-----------------|--------------------------------------------------------------------------------------------------------|---------|
+| `--config`      | Path to the SecretsManager config file, if omitted, the local FS secrets manager is used               |         |
+| `--data-dir`    | Directory for the Polygon Edge data if the local FS is used                                            |         |
+| `--genesis`     | Genesis file path, which contains chain configuration (default "./genesis.json")                       |         |
+| `--jsonrpc`     | The JSON-RPC interface (default "0.0.0.0:8545")                                                        |         |
+| `--private-key` | Hex-encoded private key of the account which executes rootchain commands                               |         |
+| `--stake-token` | Address of ERC20 token used for staking on rootchain                                                   |         |
+| `--test`        | Contract will be deployed using test account and a test stake ERC20 token will be deployed for staking |         |
+
+**Global Flags:**
+
+| Flag      | Description                                     | Example           |
+|-----------|-------------------------------------------------|-------------------|
+| `--json`  | Get all outputs in JSON format (default false). | `--json`          |
 
 </details>
 

--- a/docs/supernets/operate/deploy/rootchain-config.md
+++ b/docs/supernets/operate/deploy/rootchain-config.md
@@ -205,17 +205,23 @@ To run the deployment in test mode and use the test account provided by the Geth
 <details>
 <summary>Flags ↓</summary>
 
-| Flag                  | Description                                                               | Example                                       |
-|-----------------------|---------------------------------------------------------------------------|-----------------------------------------------|
-| `--deployer-key`      | Hex encoded private key of the account which deploys rootchain contracts  | `--deployer-key <PRIVATE_KEY>`                |
-| `--json-rpc`          | The JSON RPC rootchain IP address (e.g. http://127.0.0.1:8545)            | `--json-rpc http://127.0.0.1:8545`             |
-| `--genesis`           | Genesis file path that contains chain configuration                       | `--genesis ./genesis.json`                    |
-| `--erc1155-token`     | Existing rootchain ERC-1155 token address                                | `--erc1155-token <ERC_1155_ADDRESS>`           |
-| `--erc20-token`       | Existing rootchain ERC-20 token address                                  | `--erc20-token <ERC_20_ADDRESS>`               |
-| `--erc721-token`      | Existing rootchain ERC-721 token address                                 | `--erc721-token <ERC_721_ADDRESS>`             |
-| `--stake-manager`     | Address of stake manager contract                                             | `--stake-manager <STAKE_MANAGER_ADDRESS>`                     |
-| `--stake-token`       | Address of ERC20 token used for staking on rootchain                         | `--stake-token <STAKE_TOKEN_ADDRESS>`                         |
+| Flag                  | Description                                                              | Example                                       |
+|-----------------------|--------------------------------------------------------------------------|-----------------------------------------------|
+| `--deployer-key`      | Hex encoded private key of the account which deploys rootchain contracts | `--deployer-key <PRIVATE_KEY>`                |
+| `--json-rpc`          | The JSON RPC rootchain IP address (e.g. http://127.0.0.1:8545)           | `--json-rpc http://127.0.0.1:8545`            |
+| `--genesis`           | Genesis file path that contains chain configuration                      | `--genesis ./genesis.json`                    |
+| `--erc1155-token`     | Existing rootchain ERC-1155 token address                                | `--erc1155-token <ERC_1155_ADDRESS>`          |
+| `--erc20-token`       | Existing rootchain ERC-20 token address                                  | `--erc20-token <ERC_20_ADDRESS>`              |
+| `--erc721-token`      | Existing rootchain ERC-721 token address                                 | `--erc721-token <ERC_721_ADDRESS>`            |
+| `--stake-manager`     | Address of stake manager contract                                        | `--stake-manager <STAKE_MANAGER_ADDRESS>`     |
+| `--stake-token`       | Address of ERC20 token used for staking on rootchain                     | `--stake-token <STAKE_TOKEN_ADDRESS>`         |
 | `--test`              | Indicates whether rootchain contracts deployer is hardcoded test account | `--test`                                      |
+
+**Global Flags:**
+
+| Flag      | Description                                     | Example           |
+|-----------|--------------------------------------------- ---|-------------------|
+| `--json`  | Get all outputs in JSON format (default false). | `--json`          |
 
 </details>
 
@@ -439,16 +445,23 @@ You also need to specify the path to the genesis file using the `--genesis` opti
 <details>
 <summary>Flags ↓</summary>
 
-| Flag                  | Description                                                               | Example                                       |
-|-----------------------|---------------------------------------------------------------------------|-----------------------------------------------|
-| `--deployer-key`      | Hex encoded private key of the account which deploys rootchain contracts  | `--deployer-key <PRIVATE_KEY>`                |
-| `--json-rpc`          | The JSON RPC rootchain IP address (e.g. http://127.0.0.1:8545)            | `--json-rpc http://127.0.0.1:8545`             |
-| `--genesis`           | Genesis file path that contains chain configuration                       | `--genesis ./genesis.json`                    |
-| `--erc1155-token`     | Existing rootchain ERC-1155 token address                                | `--erc1155-token <ERC_1155_ADDRESS>`           |
-| `--erc20-token`       | Existing rootchain ERC-20 token address                                  | `--erc20-token <ERC_20_ADDRESS>`               |
-| `--erc721-token`      | Existing rootchain ERC-721 token address                                 | `--erc721-token <ERC_721_ADDRESS>`             |
-| `--stake-manager`     | Address of stake manager contract                                             | `--stake-manager <STAKE_MANAGER_ADDRESS>`                     |
-| `--stake-token`       | Address of ERC20 token used for staking on rootchain                         | `--stake-token <STAKE_TOKEN_ADDRESS>`                         |
+| Flag                  | Description                                                              | Example                                       |
+|-----------------------|--------------------------------------------------------------------------|-----------------------------------------------|
+| `--deployer-key`      | Hex encoded private key of the account which deploys rootchain contracts | `--deployer-key <PRIVATE_KEY>`                |
+| `--json-rpc`          | The JSON RPC rootchain IP address (e.g. http://127.0.0.1:8545)           | `--json-rpc http://127.0.0.1:8545`            |
+| `--genesis`           | Genesis file path that contains chain configuration                      | `--genesis ./genesis.json`                    |
+| `--erc1155-token`     | Existing rootchain ERC-1155 token address                                | `--erc1155-token <ERC_1155_ADDRESS>`          |
+| `--erc20-token`       | Existing rootchain ERC-20 token address                                  | `--erc20-token <ERC_20_ADDRESS>`              |
+| `--erc721-token`      | Existing rootchain ERC-721 token address                                 | `--erc721-token <ERC_721_ADDRESS>`            |
+| `--stake-manager`     | Address of stake manager contract                                        | `--stake-manager <STAKE_MANAGER_ADDRESS>`     |
+| `--stake-token`       | Address of ERC20 token used for staking on rootchain                     | `--stake-token <STAKE_TOKEN_ADDRESS>`         |
+| `--test`              | Indicates whether rootchain contracts deployer is hardcoded test account | `--test`                                      |
+
+**Global Flags:**
+
+| Flag      | Description                                     | Example           |
+|-----------|--------------------------------------------- ---|-------------------|
+| `--json`  | Get all outputs in JSON format (default false). | `--json`          |
 
 </details>
 


### PR DESCRIPTION
* Corrected command usage of flag `json-rpc` to `jsonrpc`
* Corrected flags of stake-manager-deploy

```bash
$ ./polygon-edge polybft stake-manager-deploy --help

Command for deploying stake manager contract on rootchain

Usage:
   polybft stake-manager-deploy [flags]

Flags:
      --config string        the path to the SecretsManager config file, if omitted, the local FS secrets manager is used
      --data-dir string      the directory for the Polygon Edge data if the local FS is used
      --genesis string       genesis file path, which contains chain configuration (default "./genesis.json")
  -h, --help                 help for stake-manager-deploy
      --jsonrpc string       the JSON-RPC interface (default "0.0.0.0:8545")
      --private-key string   hex-encoded private key of the account which executes rootchain commands
      --stake-token string   address of ERC20 token used for staking on rootchain
      --test                 indicates if command is run in test mode. If test mode is used contract will be deployed using test account and a test stake ERC20 token will be deployed to be used for staking

Global Flags:
      --json   get all outputs in json format (default false)
```

* Corrected flags for rootchain deploy

```bash
$ ./polygon-edge rootchain deploy --help

Deploys and initializes required smart contracts on the rootchain

Usage:
   rootchain deploy [flags]

Flags:
      --deployer-key string    hex-encoded private key of the account which deploys rootchain contracts
      --erc1155-token string   existing root chain ERC 1155 token address
      --erc20-token string     existing root chain root native token address
      --erc721-token string    existing root chain ERC 721 token address
      --genesis string         genesis file path, which contains chain configuration (default "./genesis.json")
  -h, --help                   help for deploy
      --json-rpc string        the JSON RPC rootchain IP address (default "http://127.0.0.1:8545")
      --stake-manager string   address of stake manager contract
      --stake-token string     address of ERC20 token used for staking on rootchain
      --test                   test indicates whether rootchain contracts deployer is hardcoded test account (otherwise provided secrets are used to resolve deployer account)

Global Flags:
      --json   get all outputs in json format (default false)
```